### PR TITLE
Remove Covers PHPDocs

### DIFF
--- a/tests/src/Traits/TestToggle.php
+++ b/tests/src/Traits/TestToggle.php
@@ -28,9 +28,6 @@ trait TestToggle
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::getName
-     *
      * @return void
      */
     public function testGetName(): void
@@ -39,11 +36,6 @@ trait TestToggle
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::getName
-     * @covers ::isActive
-     * @covers ::toArray
-     *
      * @return void
      */
     public function testToArray(): void
@@ -56,9 +48,6 @@ trait TestToggle
 
     /**
      * @dataProvider isActiveDataProvider
-     *
-     * @covers ::__construct
-     * @covers ::isActive
      *
      * @param  string  $assertMethod
      * @param  array  $values

--- a/tests/src/Traits/TestToggleProvider.php
+++ b/tests/src/Traits/TestToggleProvider.php
@@ -32,9 +32,6 @@ trait TestToggleProvider
     }
 
     /**
-     * @covers ::getToggles
-     * @covers ::refreshToggles
-     *
      * @return void
      */
     public function testNotArrayConfigToggles(): void
@@ -43,12 +40,6 @@ trait TestToggleProvider
     }
 
     /**
-     * @covers ::getToggles
-     * @covers ::getActiveToggles
-     * @covers ::activeTogglesToJson
-     * @covers ::refreshToggles
-     * @covers ::calculateToggles
-     *
      * @return void
      */
     public function testActiveTogglesToJsonNotEmpty(): void
@@ -64,10 +55,6 @@ trait TestToggleProvider
     }
 
     /**
-     * @covers ::getToggles
-     * @covers ::getActiveToggles
-     * @covers ::activeTogglesToJson
-     *
      * @return void
      */
     public function testActiveTogglesToJsonEmpty(): void
@@ -76,12 +63,6 @@ trait TestToggleProvider
     }
 
     /**
-     * @covers ::isActive
-     * @covers ::getToggles
-     * @covers ::getActiveToggles
-     * @covers ::refreshToggles
-     * @covers ::calculateToggles
-     *
      * @return void
      */
     public function testActiveToggle(): void
@@ -98,12 +79,6 @@ trait TestToggleProvider
     }
 
     /**
-     * @covers ::isActive
-     * @covers ::getToggles
-     * @covers ::getActiveToggles
-     * @covers ::refreshToggles
-     * @covers ::calculateToggles
-     *
      * @return void
      */
     public function testInActiveToggle(): void

--- a/tests/src/Unit/ApiTest.php
+++ b/tests/src/Unit/ApiTest.php
@@ -17,9 +17,6 @@ use FeatureToggle\Tests\Traits\TestToggleProvider;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\Api
- */
 class ApiTest extends TestCase
 {
     use TestToggleProvider;
@@ -44,10 +41,6 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::useMigrations
-     * @covers ::ignoreMigrations
-     * @covers ::isMigrationsEnabled
-     *
      * @return void
      */
     public function testUseOrIgnoreMigrationsMethods(): void
@@ -66,8 +59,6 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::getName
-     *
      * @return void
      */
     public function testGetName(): void
@@ -78,13 +69,6 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::setConditional
-     * @covers ::isActive
-     * @covers ::getToggles
-     * @covers ::getActiveToggles
-     * @covers ::refreshToggles
-     *
      * @return void
      */
     public function testLocalAndConditionalToggleProviders(): void
@@ -108,16 +92,6 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::setProviders
-     * @covers ::setConditional
-     * @covers ::isActive
-     * @covers ::getToggles
-     * @covers ::getActiveToggles
-     * @covers ::refreshToggles
-     * @covers \FeatureToggle\ConditionalToggleProvider::setToggle
-     * @covers \FeatureToggle\ConditionalToggleProvider::calculateToggles
-     *
      * @return void
      */
     public function testSetProvidersEloquentAndConditionalToggleProviders(): void
@@ -157,13 +131,6 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::getProvider
-     * @covers ::getConditionalProvider
-     * @covers ::getEloquentProvider
-     * @covers ::getLocalProvider
-     * @covers ::getQueryStringProvider
-     *
      * @return void
      */
     public function testGetProviderAndHelperMethods(): void
@@ -200,9 +167,6 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::getProvider
-     *
      * @return void
      */
     public function testGetProviderWithProviderNameNotLoadedThrowsError(): void
@@ -214,10 +178,6 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::setProviders
-     * @covers ::loadProvider
-     *
      * @return void
      */
     public function testSetProvidersWithUnregisterProviderDriverThrowsError(): void
@@ -232,10 +192,6 @@ class ApiTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::setProviders
-     * @covers ::loadProvider
-     *
      * @return void
      */
     public function testSetProvidersWithNonProviderContractClassThrowsError(): void

--- a/tests/src/Unit/ConditionalToggleProviderTest.php
+++ b/tests/src/Unit/ConditionalToggleProviderTest.php
@@ -9,9 +9,6 @@ use FeatureToggle\ConditionalToggleProvider;
 use FeatureToggle\Tests\Traits\TestToggleProvider;
 use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\ConditionalToggleProvider
- */
 class ConditionalToggleProviderTest extends TestCase
 {
     use TestToggleProvider;

--- a/tests/src/Unit/EloquentToggleProviderTest.php
+++ b/tests/src/Unit/EloquentToggleProviderTest.php
@@ -16,9 +16,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
 use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\EloquentToggleProvider
- */
 class EloquentToggleProviderTest extends TestCase
 {
     use RefreshDatabase, TestToggleProvider;

--- a/tests/src/Unit/LocalToggleProviderTest.php
+++ b/tests/src/Unit/LocalToggleProviderTest.php
@@ -9,9 +9,6 @@ use FeatureToggle\LocalToggleProvider;
 use FeatureToggle\Tests\Traits\TestToggleProvider;
 use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\LocalToggleProvider
- */
 class LocalToggleProviderTest extends TestCase
 {
     use TestToggleProvider;

--- a/tests/src/Unit/QueryStringToggleProviderTest.php
+++ b/tests/src/Unit/QueryStringToggleProviderTest.php
@@ -10,9 +10,6 @@ use FeatureToggle\QueryStringToggleProvider;
 use FeatureToggle\Tests\Traits\TestToggleProvider;
 use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\QueryStringToggleProvider
- */
 class QueryStringToggleProviderTest extends TestCase
 {
     use TestToggleProvider;

--- a/tests/src/Unit/Toggle/ConditionalTest.php
+++ b/tests/src/Unit/Toggle/ConditionalTest.php
@@ -10,9 +10,6 @@ use FeatureToggle\Toggle\FeatureToggle;
 use FeatureToggle\Tests\Traits\TestToggle;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\Toggle\Conditional
- */
 class ConditionalTest extends TestCase
 {
     use TestToggle;

--- a/tests/src/Unit/Toggle/FeatureToggleTest.php
+++ b/tests/src/Unit/Toggle/FeatureToggleTest.php
@@ -9,9 +9,6 @@ use FeatureToggle\Toggle\FeatureToggle;
 use FeatureToggle\Tests\Traits\TestToggle;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\Toggle\FeatureToggle
- */
 class FeatureToggleTest extends TestCase
 {
     use TestToggle;

--- a/tests/src/Unit/Toggle/LocalTest.php
+++ b/tests/src/Unit/Toggle/LocalTest.php
@@ -9,9 +9,6 @@ use FeatureToggle\Tests\TestCase;
 use FeatureToggle\Tests\Traits\TestToggle;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\Toggle\Local
- */
 class LocalTest extends TestCase
 {
     use TestToggle;

--- a/tests/src/Unit/Toggle/QueryStringTest.php
+++ b/tests/src/Unit/Toggle/QueryStringTest.php
@@ -7,9 +7,6 @@ namespace FeatureToggle\Tests\Unit\Toggle;
 use FeatureToggle\Toggle\QueryString;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
 
-/**
- * @coversDefaultClass \FeatureToggle\Toggle\QueryString
- */
 class QueryStringTest extends LocalTest
 {
     /**


### PR DESCRIPTION
## Description
Removed all covers php docs. That way coverage is discovered dynamically instead of manually via `@covers`.