### PR TITLE
Session Toggle Provider

### DIFF
--- a/config/feature-toggle.php
+++ b/config/feature-toggle.php
@@ -38,7 +38,7 @@ return [
      | or not, will be used as the status value.
      |
      | Default Drivers: "conditional", "eloquent", "local", "querystring",
-     |                  "redis"
+     |                  "redis", "session"
      |
      */
 
@@ -83,6 +83,7 @@ return [
      | - 'local' => \FeatureToggle\LocalToggleProvider::class,
      | - 'querystring' => \FeatureToggle\QueryStringToggleProvider::class,
      | - 'redis' => \FeatureToggle\RedisToggleProvider::class,
+     | - 'session' => \FeatureToggle\SessionToggleProvider::class,
      |
      */
 

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ A simple feature toggle api for Laravel applications.
         - [Configure Query String Keys](#configure-query-string-keys)
         - [Add Api Key Authorization](#add-api-key-authorization)
     - [Redis Toggle Provider](#redis-toggle-provider)
+    - [Session Toggle Provider](#session-toggle-provider)
 - [Frontend Feature Toggle Api](#frontend-feature-toggle-api)
 - [Road Map](#road-map)
 
@@ -209,6 +210,7 @@ The default feature toggle providers are as follows:
 - `local` (config)
 - `querystring`
 - `redis`
+- `session`
 
 You can access these directly via:
 ```php
@@ -453,6 +455,21 @@ There are three options that can be configured:
     ],
 ],
 ```
+
+Current implementation requires the array of toggles to be serialized in redis, you can use
+`Illuminate\Cache\RedisStore` `forever` method to persist toggle values.
+
+### Session Toggle Provider
+To use the `session` driver you will need to update the `feature-toggle` config/`setProviders` method call,
+place the following within the `providers` key:
+```php
+'providers' => [
+    [
+        'driver' => 'session',
+    ],
+],
+```
+
 
 ## Frontend Feature Toggle Api
 Place the following in your main layout blade template in the `<head>` tag.

--- a/src/Api.php
+++ b/src/Api.php
@@ -24,7 +24,7 @@ class Api implements ApiContract
     /**
      * @var string
      */
-    protected $name;
+    protected static $name = 'primary';
 
     /**
      * @var ToggleProviderContract[]
@@ -41,7 +41,7 @@ class Api implements ApiContract
      */
     public function __construct(array $providers, array $options = [])
     {
-        $this->name = 'primary-'.Str::random(5);
+        self::$name = 'primary-'.Str::random(5);
 
         static::$options = static::$options + $options;
 
@@ -80,9 +80,9 @@ class Api implements ApiContract
     /**
      * @return string
      */
-    public function getName(): string
+    public static function getName(): string
     {
-        return $this->name;
+        return self::$name;
     }
 
     /**
@@ -90,7 +90,7 @@ class Api implements ApiContract
      */
     public function &getConditionalProvider(): ConditionalToggleProvider
     {
-        return $this->getProvider(ConditionalToggleProvider::NAME);
+        return $this->getProvider(ConditionalToggleProvider::getName());
     }
 
     /**
@@ -98,7 +98,7 @@ class Api implements ApiContract
      */
     public function getEloquentProvider(): EloquentToggleProvider
     {
-        return $this->getProvider(EloquentToggleProvider::NAME);
+        return $this->getProvider(EloquentToggleProvider::getName());
     }
 
     /**
@@ -106,7 +106,7 @@ class Api implements ApiContract
      */
     public function getLocalProvider(): LocalToggleProvider
     {
-        return $this->getProvider(LocalToggleProvider::NAME);
+        return $this->getProvider(LocalToggleProvider::getName());
     }
 
     /**
@@ -114,7 +114,7 @@ class Api implements ApiContract
      */
     public function getQueryStringProvider(): QueryStringToggleProvider
     {
-        return $this->getProvider(QueryStringToggleProvider::NAME);
+        return $this->getProvider(QueryStringToggleProvider::getName());
     }
 
     /**
@@ -122,7 +122,15 @@ class Api implements ApiContract
      */
     public function getRedisProvider(): RedisToggleProvider
     {
-        return $this->getProvider(RedisToggleProvider::NAME);
+        return $this->getProvider(RedisToggleProvider::getName());
+    }
+
+    /**
+     * @return ToggleProviderContract|SessionToggleProvider
+     */
+    public function getSessionProvider(): SessionToggleProvider
+    {
+        return $this->getProvider(SessionToggleProvider::getName());
     }
 
     /**

--- a/src/Concerns/ToggleProvider.php
+++ b/src/Concerns/ToggleProvider.php
@@ -16,6 +16,11 @@ trait ToggleProvider
     protected $toggles;
 
     /**
+     * @return string
+     */
+    abstract public static function getName(): string;
+
+    /**
      * Check if feature toggle is active.
      *
      * @param  string  $name
@@ -86,5 +91,23 @@ trait ToggleProvider
      *
      * @return $this|ToggleProviderContract
      */
-    abstract public function refreshToggles(): ToggleProviderContract;
+
+    /**
+     * Initialize all feature toggles.
+     *
+     * @return $this
+     */
+    public function refreshToggles(): ToggleProviderContract
+    {
+        $this->toggles = $this->calculateToggles();
+
+        return $this;
+    }
+
+    /**
+     * Get all toggles from source and normalize.
+     *
+     * @return ToggleContract[]|Collection
+     */
+    abstract protected function calculateToggles(): Collection;
 }

--- a/src/ConditionalToggleProvider.php
+++ b/src/ConditionalToggleProvider.php
@@ -4,21 +4,28 @@ declare(strict_types=1);
 
 namespace FeatureToggle;
 
+use FeatureToggle\Concerns\ToggleProvider;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
+use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 use FeatureToggle\Toggle\Conditional as ConditionalToggle;
 use Illuminate\Support\Collection;
 
-class ConditionalToggleProvider extends LocalToggleProvider
+class ConditionalToggleProvider implements ToggleProviderContract
 {
-    /**
-     * @var string
-     */
-    const NAME = 'conditional';
+    use ToggleProvider;
 
     /**
      * @var array
      */
     protected $conditions = [];
+
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return 'conditional';
+    }
 
     /**
      * @param  string  $name

--- a/src/Contracts/ToggleProvider.php
+++ b/src/Contracts/ToggleProvider.php
@@ -15,7 +15,7 @@ interface ToggleProvider
     /**
      * @return string
      */
-    public function getName(): string;
+    public static function getName(): string;
 
     /**
      * Check if feature toggle is active.

--- a/src/EloquentToggleProvider.php
+++ b/src/EloquentToggleProvider.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace FeatureToggle;
 
+use FeatureToggle\Concerns\ToggleProvider;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
+use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 use FeatureToggle\Toggle\Eloquent;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Throwable;
 
-class EloquentToggleProvider extends LocalToggleProvider
+class EloquentToggleProvider implements ToggleProviderContract
 {
-    /**
-     * @var string
-     */
-    const NAME = 'eloquent';
+    use ToggleProvider;
 
     /**
      * @var string
@@ -31,6 +30,14 @@ class EloquentToggleProvider extends LocalToggleProvider
     public function __construct(?string $model = null)
     {
         $this->model = $model ?? Eloquent::class;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return 'eloquent';
     }
 
     /**

--- a/src/LocalToggleProvider.php
+++ b/src/LocalToggleProvider.php
@@ -8,6 +8,7 @@ use FeatureToggle\Concerns\ToggleProvider;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
 use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 use FeatureToggle\Toggle\Local as LocalToggle;
+use Illuminate\Contracts\Config\Repository as ConfigContract;
 use Illuminate\Support\Collection;
 
 class LocalToggleProvider implements ToggleProviderContract
@@ -15,28 +16,26 @@ class LocalToggleProvider implements ToggleProviderContract
     use ToggleProvider;
 
     /**
-     * @var string
+     * @var \Illuminate\Contracts\Config\Repository
      */
-    const NAME = 'local';
+    protected $config;
+
+    /**
+     * LocalToggleProvider constructor.
+     *
+     * @param  \Illuminate\Contracts\Config\Repository  $config
+     */
+    public function __construct(ConfigContract $config)
+    {
+        $this->config = $config;
+    }
 
     /**
      * @return string
      */
-    public function getName(): string
+    public static function getName(): string
     {
-        return static::NAME;
-    }
-
-    /**
-     * Initialize all feature toggles.
-     *
-     * @return $this
-     */
-    public function refreshToggles(): ToggleProviderContract
-    {
-        $this->toggles = $this->calculateToggles();
-
-        return $this;
+        return 'local';
     }
 
     /**
@@ -62,7 +61,7 @@ class LocalToggleProvider implements ToggleProviderContract
      */
     protected function calculateLocalToggles(): array
     {
-        $localFeatures = config('feature-toggle.toggles', []);
+        $localFeatures = $this->config->get('feature-toggle.toggles', []);
 
         if (! is_array($localFeatures)) {
             return [];

--- a/src/LocalToggleProvider.php
+++ b/src/LocalToggleProvider.php
@@ -21,13 +21,20 @@ class LocalToggleProvider implements ToggleProviderContract
     protected $config;
 
     /**
+     * @var string
+     */
+    protected $key;
+
+    /**
      * LocalToggleProvider constructor.
      *
      * @param  \Illuminate\Contracts\Config\Repository  $config
+     * @param  string  $key
      */
-    public function __construct(ConfigContract $config)
+    public function __construct(ConfigContract $config, string $key = 'feature-toggle.toggles')
     {
         $this->config = $config;
+        $this->key = $key;
     }
 
     /**
@@ -61,7 +68,7 @@ class LocalToggleProvider implements ToggleProviderContract
      */
     protected function calculateLocalToggles(): array
     {
-        $localFeatures = $this->config->get('feature-toggle.toggles', []);
+        $localFeatures = $this->config->get($this->key, []);
 
         if (! is_array($localFeatures)) {
             return [];

--- a/src/QueryStringToggleProvider.php
+++ b/src/QueryStringToggleProvider.php
@@ -4,17 +4,16 @@ declare(strict_types=1);
 
 namespace FeatureToggle;
 
+use FeatureToggle\Concerns\ToggleProvider;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
+use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 use FeatureToggle\Toggle\QueryString;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 
-class QueryStringToggleProvider extends LocalToggleProvider
+class QueryStringToggleProvider implements ToggleProviderContract
 {
-    /**
-     * @var string
-     */
-    const NAME = 'querystring';
+    use ToggleProvider;
 
     /**
      * @var \Illuminate\Http\Request
@@ -62,6 +61,14 @@ class QueryStringToggleProvider extends LocalToggleProvider
         $this->inactiveKey = $inactiveKey;
         $this->apiInputKey = $apiInputKey;
         $this->apiKey = $apiKey;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return 'querystring';
     }
 
     /**

--- a/src/RedisToggleProvider.php
+++ b/src/RedisToggleProvider.php
@@ -4,18 +4,17 @@ declare(strict_types=1);
 
 namespace FeatureToggle;
 
+use FeatureToggle\Concerns\ToggleProvider;
 use FeatureToggle\Contracts\Toggle as ToggleContract;
+use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
 use FeatureToggle\Toggle\Redis as RedisToggle;
 use Illuminate\Contracts\Redis\Factory as Redis;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Collection;
 
-class RedisToggleProvider extends LocalToggleProvider
+class RedisToggleProvider implements ToggleProviderContract
 {
-    /**
-     * @var string
-     */
-    const NAME = 'redis';
+    use ToggleProvider;
 
     /**
      * The Redis connection that should be used.
@@ -66,9 +65,17 @@ class RedisToggleProvider extends LocalToggleProvider
     }
 
     /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return 'redis';
+    }
+
+    /**
      * Get all toggles from redis and normalize.
      *
-     * @return Collection
+     * @return ToggleContract[]|Collection
      */
     public function calculateToggles(): Collection
     {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,6 +26,7 @@ class ServiceProvider extends SupportServiceProvider
         'local' => LocalToggleProvider::class,
         'querystring' => QueryStringToggleProvider::class,
         'redis' => RedisToggleProvider::class,
+        'session' => SessionToggleProvider::class,
     ];
 
     /**

--- a/src/SessionToggleProvider.php
+++ b/src/SessionToggleProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FeatureToggle;
+
+use FeatureToggle\Concerns\ToggleProvider;
+use FeatureToggle\Contracts\Toggle as ToggleContract;
+use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
+use FeatureToggle\Toggle\Session as SessionToggle;
+use Illuminate\Contracts\Session\Session;
+use Illuminate\Support\Collection;
+
+class SessionToggleProvider implements ToggleProviderContract
+{
+    use ToggleProvider;
+
+    /**
+     * @var \Illuminate\Contracts\Session\Session
+     */
+    protected $session;
+
+    /**
+     * SessionToggleProvider constructor.
+     *
+     * @param  \Illuminate\Contracts\Session\Session  $session
+     */
+    public function __construct(Session $session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * @return string
+     */
+    public static function getName(): string
+    {
+        return 'session';
+    }
+
+    /**
+     * Get all toggles from session and normalize.
+     *
+     * @return ToggleContract[]|Collection
+     */
+    protected function calculateToggles(): Collection
+    {
+        $toggles = collect();
+
+        foreach ($this->calculateSessionToggles() as $name => $isActive) {
+            $toggles->put($name, new SessionToggle($name, $isActive));
+        }
+
+        return $toggles;
+    }
+
+    /**
+     * Pull feature toggles from the application user session.
+     *
+     * @return array
+     */
+    protected function calculateSessionToggles(): array
+    {
+        $sessionFeatures = $this->session->get('feature-toggles', []);
+
+        if (! is_array($sessionFeatures)) {
+            return [];
+        }
+
+        return $sessionFeatures;
+    }
+}

--- a/src/SessionToggleProvider.php
+++ b/src/SessionToggleProvider.php
@@ -16,6 +16,11 @@ class SessionToggleProvider implements ToggleProviderContract
     use ToggleProvider;
 
     /**
+     * @var string
+     */
+    protected $key;
+
+    /**
      * @var \Illuminate\Contracts\Session\Session
      */
     protected $session;
@@ -24,9 +29,11 @@ class SessionToggleProvider implements ToggleProviderContract
      * SessionToggleProvider constructor.
      *
      * @param  \Illuminate\Contracts\Session\Session  $session
+     * @param  string|null  $key
      */
-    public function __construct(Session $session)
+    public function __construct(Session $session, string $key = 'feature-toggles')
     {
+        $this->key = $key;
         $this->session = $session;
     }
 
@@ -61,7 +68,7 @@ class SessionToggleProvider implements ToggleProviderContract
      */
     protected function calculateSessionToggles(): array
     {
-        $sessionFeatures = $this->session->get('feature-toggles', []);
+        $sessionFeatures = $this->session->get($this->key, []);
 
         if (! is_array($sessionFeatures)) {
             return [];

--- a/src/Toggle/AbstractToggle.php
+++ b/src/Toggle/AbstractToggle.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FeatureToggle\Toggle;
+
+use FeatureToggle\Concerns\Toggle;
+use FeatureToggle\Contracts\Toggle as ToggleContract;
+use Illuminate\Contracts\Support\Arrayable;
+
+abstract class AbstractToggle implements ToggleContract, Arrayable
+{
+    use Toggle;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var bool
+     */
+    protected $is_active = false;
+
+    /**
+     * Local constructor.
+     *
+     * @param  string  $name
+     * @param  string|bool|int  $isActive
+     */
+    public function __construct(string $name, $isActive)
+    {
+        $this->name = $name;
+        $this->setIsActive($isActive);
+    }
+}

--- a/src/Toggle/Conditional.php
+++ b/src/Toggle/Conditional.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FeatureToggle\Toggle;
 
-class Conditional extends Local
+class Conditional extends AbstractToggle
 {
     /**
      * @var callable

--- a/src/Toggle/Local.php
+++ b/src/Toggle/Local.php
@@ -4,33 +4,9 @@ declare(strict_types=1);
 
 namespace FeatureToggle\Toggle;
 
-use FeatureToggle\Concerns\Toggle;
-use FeatureToggle\Contracts\Toggle as ToggleContract;
-use Illuminate\Contracts\Support\Arrayable;
-
-class Local implements ToggleContract, Arrayable
+/**
+ * @codeCoverageIgnore
+ */
+class Local extends AbstractToggle
 {
-    use Toggle;
-
-    /**
-     * @var string
-     */
-    protected $name;
-
-    /**
-     * @var bool
-     */
-    protected $is_active = false;
-
-    /**
-     * Local constructor.
-     *
-     * @param  string  $name
-     * @param  string|bool|int  $isActive
-     */
-    public function __construct(string $name, $isActive)
-    {
-        $this->name = $name;
-        $this->setIsActive($isActive);
-    }
 }

--- a/src/Toggle/Redis.php
+++ b/src/Toggle/Redis.php
@@ -7,6 +7,6 @@ namespace FeatureToggle\Toggle;
 /**
  * @codeCoverageIgnore
  */
-class Redis extends Local
+class Redis extends AbstractToggle
 {
 }

--- a/src/Toggle/Session.php
+++ b/src/Toggle/Session.php
@@ -7,6 +7,6 @@ namespace FeatureToggle\Toggle;
 /**
  * @codeCoverageIgnore
  */
-class QueryString extends AbstractToggle
+class Session extends AbstractToggle
 {
 }

--- a/tests/src/Unit/ApiTest.php
+++ b/tests/src/Unit/ApiTest.php
@@ -12,6 +12,7 @@ use FeatureToggle\Facades\FeatureToggleApi;
 use FeatureToggle\LocalToggleProvider;
 use FeatureToggle\QueryStringToggleProvider;
 use FeatureToggle\RedisToggleProvider;
+use FeatureToggle\SessionToggleProvider;
 use FeatureToggle\Tests\Concerns\TestToggleProvider;
 use FeatureToggle\Tests\Concerns\TestToggleValidation;
 use FeatureToggle\Tests\TestCase;
@@ -130,6 +131,16 @@ class ApiTest extends TestCase
     }
 
     /**
+     * @returns void
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public function testGetSessionProviderReturnsInstance(): void
+    {
+        $sessionProvider = feature_toggle_api()->loadProvider('session')->getSessionProvider();
+        $this->assertInstanceOf(SessionToggleProvider::class, $sessionProvider);
+    }
+
+    /**
      * @return void
      */
     public function testLocalAndConditionalToggleProviders(): void
@@ -149,8 +160,8 @@ class ApiTest extends TestCase
         $this->assertFalse($featureToggleApi->isActive('bar'), '"bar" toggle check, should BE false.');
         $this->assertTrue($featureToggleApi->isActive('baz'), '"baz" toggle check, should BE true.');
         $this->assertCount(3, $featureToggleApi->getToggles());
-        $this->assertCount(2, $featureToggleApi->getProviderToggles(LocalToggleProvider::NAME));
-        $this->assertCount(2, $featureToggleApi->getProviderToggles(ConditionalToggleProvider::NAME));
+        $this->assertCount(2, $featureToggleApi->getProviderToggles(LocalToggleProvider::getName()));
+        $this->assertCount(2, $featureToggleApi->getProviderToggles(ConditionalToggleProvider::getName()));
         $this->assertCount(1, $featureToggleApi->getActiveToggles());
     }
 
@@ -202,19 +213,19 @@ class ApiTest extends TestCase
     {
         feature_toggle_api()->setProviders([
             [
-                'driver' => LocalToggleProvider::NAME,
+                'driver' => LocalToggleProvider::getName(),
             ],
             [
-                'driver' => ConditionalToggleProvider::NAME,
+                'driver' => ConditionalToggleProvider::getName(),
             ],
             [
-                'driver' => EloquentToggleProvider::NAME,
+                'driver' => EloquentToggleProvider::getName(),
             ],
             [
-                'driver' => QueryStringToggleProvider::NAME,
+                'driver' => QueryStringToggleProvider::getName(),
             ],
         ]);
-        $providerLocal = feature_toggle_api()->getProvider(LocalToggleProvider::NAME);
+        $providerLocal = feature_toggle_api()->getProvider(LocalToggleProvider::getName());
         $this->assertInstanceOf(LocalToggleProvider::class, $providerLocal);
 
         $methods = [
@@ -237,7 +248,7 @@ class ApiTest extends TestCase
      */
     public function testLoadProviderAndRefreshProvider(): void
     {
-        $driver = LocalToggleProvider::NAME;
+        $driver = LocalToggleProvider::getName();
         feature_toggle_api()->setProviders([]);
         $this->assertCount(0, feature_toggle_api()->getProviders());
 

--- a/tests/src/Unit/SessionToggleProviderTest.php
+++ b/tests/src/Unit/SessionToggleProviderTest.php
@@ -5,29 +5,29 @@ declare(strict_types=1);
 namespace FeatureToggle\Tests\Unit;
 
 use FeatureToggle\Contracts\ToggleProvider as ToggleProviderContract;
-use FeatureToggle\LocalToggleProvider;
+use FeatureToggle\SessionToggleProvider;
 use FeatureToggle\Tests\Concerns\TestToggleProvider;
 use FeatureToggle\Tests\TestCase;
 
-class LocalToggleProviderTest extends TestCase
+class SessionToggleProviderTest extends TestCase
 {
     use TestToggleProvider;
 
     /**
-     * @return \FeatureToggle\LocalToggleProvider
+     * @return \FeatureToggle\SessionToggleProvider
      */
-    protected function getToggleProvider(): LocalToggleProvider
+    protected function getToggleProvider(): SessionToggleProvider
     {
-        return (new LocalToggleProvider($this->app['config']))->refreshToggles();
+        return (new SessionToggleProvider($this->app['session']->driver()))->refreshToggles();
     }
 
     /**
      * @param  array|null  $toggles
-     * @return \FeatureToggle\LocalToggleProvider|ToggleProviderContract
+     * @return \FeatureToggle\SessionToggleProvider|ToggleProviderContract
      */
     protected function setToggles(array $toggles = null): ToggleProviderContract
     {
-        $this->app['config']->set('feature-toggle.toggles', $toggles);
+        $this->app['session']->put('feature-toggles', $toggles);
 
         return $this->getToggleProvider();
     }


### PR DESCRIPTION
## What this did
- Added `SessionToggleProvider`.
- Moved to using `getName` instead of `const NAME` throughout toggle provider classes.
- Each `ToggleProvider` class now implements `ToggleProviderContract` instead of extending `LocalToggleProvider`.
- Each `Toggle` class now extends `AbstractToggle` instead of extending the `Local` toggle class.
